### PR TITLE
State Details Page Layout

### DIFF
--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -67,7 +67,6 @@ const mouseMove = (event, setActiveRegion, setTooltipStyle) => {
 }
 
 const handleClick = (event, activeRegion) => {
-  console.log(activeRegion.id)
   navigate(`/${activeRegion.id}`)
 }
 

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -116,8 +116,6 @@ const StateDetailsPage = ({location, data}) => {
     placeEmissions.dumps_farms_industrial_other +
     placeEmissions.transportation
 
-
-
   const buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1)
   const powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1)
   const transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1)
@@ -188,6 +186,22 @@ const StateDetailsPage = ({location, data}) => {
           [insert state emissions graph highlighting buildings]
         </p>
 
+        <div className="action-panel">
+          <h3 className="h4 font-weight-bold">What should I do?</h3>
+
+          {/* TODO: Make these link somewhere */}
+          <ul className="mt-3 pl-4 mb-0">
+            <li>
+              <a href="http://example.com">First, electrify your building(s)</a>
+            </li>
+            <li>
+              <a href="http://example.com">
+                Then push your local politicians to electrify the rest
+              </a>
+            </li>
+          </ul>
+        </div>
+
         <hr className="mt-5"/>
       </div>
 
@@ -221,6 +235,24 @@ const StateDetailsPage = ({location, data}) => {
         <p className="h4 mt-5 text-muted">
           [insert state emissions graph highlighting transportation]
         </p>
+
+        <div className="action-panel">
+          <h3 className="h4 font-weight-bold">What should I do?</h3>
+
+          {/* TODO: Make these link somewhere */}
+          <ul className="mt-3 pl-4 mb-0">
+            <li>
+              <a href="http://example.com">
+                If you have a car, buy an EV
+              </a>
+            </li>
+            <li>
+              <a href="http://example.com">
+                Then push your local politicians to electrify the rest
+              </a>
+            </li>
+          </ul>
+        </div>
 
         <hr className="mt-5"/>
       </div>
@@ -293,7 +325,21 @@ const StateDetailsPage = ({location, data}) => {
           [insert state emissions graph highlighting power]
         </p>
 
-        <hr className="mt-5"/>
+        <div className="action-panel">
+          <h3 className="h4 font-weight-bold">What should I do?</h3>
+
+          {/* TODO: Make these link somewhere */}
+          <ul className="mt-3 pl-4 mb-0">
+            <li>
+              <a href="http://example.com">Install solar panels and a battery in your building</a>
+            </li>
+            <li>
+              <a href="http://example.com">
+                Support the construction of grid-scale wind and solar
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </Layout>
   )

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -107,10 +107,10 @@ const StateDetailsPage = ({location, data}) => {
 
   const currPlaceData = placesData[currentPlace]
 
-  let buildingsPrcnt, powerPrcnt, transportPrcnt;
+  let buildingsPrcnt, powerPrcnt, transportPrcnt
 
   // NOTE: We don't have emissions for all states (like Guam)
-  const placeAllEmissions = currPlaceData.emissions;
+  const placeAllEmissions = currPlaceData.emissions
 
   if (placeAllEmissions) {
     // Get the last year of emissions data we have to use for showing the

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -128,7 +128,7 @@ const StateDetailsPage = ({location, data}) => {
     <Layout>
       <SEO />
 
-      <div className='col-12 c-4'>
+      <div className='col-6'>
         <h1 className='mr-4 mb-3'>{placeData.name}</h1>
         <ChoroplethMap emissions={countryEmissions} sidebar={false} selected_location={currentPlace}/>
       </div>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -101,16 +101,30 @@ const currentYear = new Date().getFullYear();
 const cutPerYearPrcnt = (100 / (2050 - currentYear)).toFixed(1);
 
 const StateDetailsPage = ({location, data}) => {
-  const emissions_2018 = get_2018_emissions(data)
   const currentPlace = location.pathname.split("/")[1]
-
+  const countryEmissions = get_2018_emissions(data)
   const placesData = getPlacesData(data)
-  const emissions= emissions_2018
-  const currentPlaceData = placesData[currentPlace];
 
-  const placeTitle = currentPlaceData.name;
+  const currPlaceData = placesData[currentPlace];
 
-  const [placeData, setPlaceData] = useState(currentPlaceData)
+  // Get the last year of emissions data we have to use for showing the
+  // breakdown of how much emission comes from each source in this state
+  const placeEmissions = currPlaceData.emissions[currPlaceData.emissions.length - 1];
+
+  const totalLatestEmissions = placeEmissions.buildings +
+    placeEmissions.dirty_power +
+    placeEmissions.dumps_farms_industrial_other +
+    placeEmissions.transportation;
+
+
+
+  const buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1);
+  const powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1);
+  const transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1);
+
+  const placeTitle = currPlaceData.name;
+
+  const [placeData, setPlaceData] = useState(currPlaceData)
 
   return (
     <Layout>
@@ -118,44 +132,168 @@ const StateDetailsPage = ({location, data}) => {
 
       <div className='col-12 c-4'>
         <h1 className='mr-4 mb-3'>{placeData.name}</h1>
-        <ChoroplethMap emissions={emissions} sidebar={false} selected_location={currentPlace}/>
+        <ChoroplethMap emissions={countryEmissions} sidebar={false} selected_location={currentPlace}/>
       </div>
+
+      {/* Intro Section */}
       <div className='col-12'>
-        <p class="h1 mt-5 mb-5">
+        <p className="h1 mt-5 mb-5">
           To get to <strong>zero</strong> by 2050, {placeTitle} must
           cut climate pollution by <strong>{cutPerYearPrcnt}% a year.</strong>
         </p>
 
-        <p class="h4 font-weight-bold">Emissions in {placeTitle}</p>
-        <p class="h6 text-muted">
+        <p className="h4 font-weight-bold">Emissions in {placeTitle}</p>
+        <p className="h6 text-muted">
           Metric tons of carbon dioxide equivalent (MTCO2e) emissions
           </p>
         <StackedBarChart emissions_data={placeData.emissions}/>
 
-        <p class="h1 text-center mt-5">We can do it. Here's how.</p>
+        <p className="h1 text-center mt-5">We can do it. Here's how.</p>
 
-        <hr/>
+        <hr className="mt-5"/>
       </div>
+
+      {/* Buildings Section */}
       <div className='col-12'>
-        <h2 class="h5">Buildings</h2>
+        <h2 className="h4 mt-4 ml-5 font-weight-bold">Buildings</h2>
 
-        <strong>?%</strong>
+        <p className="h3 mt-5">
+          <strong>{buildingsPrcnt}%</strong> of emissions in {placeTitle} comes from buildings.
+        </p>
 
-        <hr/>
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting buildings]
+        </p>
+
+        <p>
+          Mostly from heating them.
+
+          ?% of the pollution of your typical home comes from heating your space, water, and food.
+        </p>
+
+        <p className="h3 mt-5">
+          To stop this pollution, we need to electrify our furnaces, water boilers, and stoves.
+        </p>
+
+        <p className="h3 mt-5">
+          And we need to do this for all ? buildings in {placeTitle}<br/>
+          (That's around ? per year)
+        </p>
+
+        <p className="h3 mt-5">
+          That will solve {buildingsPrcnt}% of the problem.
+        </p>
+
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting buildings]
+        </p>
+
+        <hr className="mt-5"/>
       </div>
+
+      {/* Transportation Section */}
       <div className='col-12'>
-        <h2 class="h5">Getting around</h2>
+        <h2 className="h4 mt-4 ml-5 font-weight-bold">Getting around</h2>
 
-        <strong>?%</strong>
+        <p className="h3 mt-5">
+          <strong>{transportPrcnt}%</strong> of emissions in {placeTitle} comes from cars, trucks, and planes.
+        </p>
 
-        <hr/>
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting transportation]
+        </p>
+
+        <p>Mostly from our cars</p>
+
+        <p className="h3 mt-5">
+          To cut this pollution, replace your car with an EV.
+        </p>
+
+        <p className="h3 mt-5">
+          And we need to do this for all ? cars in {placeTitle}<br/>
+          (That's around ? a year.)
+        </p>
+
+        <p className="h3 mt-5">
+          That will solve {transportPrcnt}% of the problem.
+        </p>
+
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting transportation]
+        </p>
+
+        <hr className="mt-5"/>
       </div>
+
+      {/* Power Section */}
       <div className='col-12'>
-        <h2 class="h5">Power generation</h2>
+        <h2 className="h4 mt-4 ml-5 font-weight-bold">Power generation</h2>
 
-        <strong>?%</strong>
+        <p className="h3 mt-5">
+          <strong>{powerPrcnt}%</strong> of emissions in {placeTitle} comes from making power.
+        </p>
 
-        <hr/>
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting power]
+        </p>
+
+        <p className="h3 mt-5">
+          Specifically from coal and gas plants.
+        </p>
+
+        <p className="h3 mt-5">
+          To cut this pollution, we need to replace dirty power plants with
+          clean ones. (mostly wind and solar)
+        </p>
+
+        <p className="h3 mt-5">
+          And we need to do this for all <strong>? coal plants in {placeTitle}</strong>
+        </p>
+
+        <p className="h3 mt-5">
+          ...and all <strong>? gas plants</strong>.
+        </p>
+
+        <p className="h3 mt-5">
+          ...and help those workers find good jobs.
+        </p>
+
+        <p className="h3 mt-5">
+          But wait! Remember how we electrified all cars and buildings?
+        </p>
+
+        <p className="h3 mt-5">
+          Our machines don't pollute now, because they run on electricity!
+        </p>
+
+        <p className="h3 mt-5">
+          But that means we need to make more power for those new electric
+          machines - <strong>twice</strong> as much power as we make now!
+        </p>
+
+        <p className="h3 mt-5">
+          And <strong>all of it needs to be clean power!</strong>
+        </p>
+
+        <p className="h3 mt-5">
+          So to cut the climate pollution from our power, cars, and buildings we need to BUILD ? wind and solar farms. <br/>
+          (That's ? a year)
+        </p>
+
+        <p className="h4 mt-5 text-muted">
+          [insert animated map here]
+        </p>
+
+
+        <p className="h3 mt-5">
+          That will solve {powerPrcnt}% of the problem.
+        </p>
+
+        <p className="h4 mt-5 text-muted">
+          [insert state emissions graph highlighting power]
+        </p>
+
+        <hr className="mt-5"/>
       </div>
     </Layout>
   )

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -94,35 +94,35 @@ const getPlacesData = (data) => {
   return allPlacesData
 }
 
-const currentYear = new Date().getFullYear();
+const currentYear = new Date().getFullYear()
 
 // We want to get to 0 by 2050 and we use our current emissions as a start,
 // so the % to cut by is 100 divided by the number of years we have
-const cutPerYearPrcnt = (100 / (2050 - currentYear)).toFixed(1);
+const cutPerYearPrcnt = (100 / (2050 - currentYear)).toFixed(1)
 
 const StateDetailsPage = ({location, data}) => {
   const currentPlace = location.pathname.split("/")[1]
   const countryEmissions = get_2018_emissions(data)
   const placesData = getPlacesData(data)
 
-  const currPlaceData = placesData[currentPlace];
+  const currPlaceData = placesData[currentPlace]
 
   // Get the last year of emissions data we have to use for showing the
   // breakdown of how much emission comes from each source in this state
-  const placeEmissions = currPlaceData.emissions[currPlaceData.emissions.length - 1];
+  const placeEmissions = currPlaceData.emissions[currPlaceData.emissions.length - 1]
 
   const totalLatestEmissions = placeEmissions.buildings +
     placeEmissions.dirty_power +
     placeEmissions.dumps_farms_industrial_other +
-    placeEmissions.transportation;
+    placeEmissions.transportation
 
 
 
-  const buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1);
-  const powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1);
-  const transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1);
+  const buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1)
+  const powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1)
+  const transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1)
 
-  const placeTitle = currPlaceData.name;
+  const placeTitle = currPlaceData.name
 
   const [placeData, setPlaceData] = useState(currPlaceData)
 
@@ -145,7 +145,7 @@ const StateDetailsPage = ({location, data}) => {
         <p className="h4 font-weight-bold">Emissions in {placeTitle}</p>
         <p className="h6 text-muted">
           Metric tons of carbon dioxide equivalent (MTCO2e) emissions
-          </p>
+        </p>
         <StackedBarChart emissions_data={placeData.emissions}/>
 
         <p className="h1 text-center mt-5">We can do it. Here's how.</p>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -94,29 +94,68 @@ const getPlacesData = (data) => {
   return allPlacesData
 }
 
+const currentYear = new Date().getFullYear();
+
+// We want to get to 0 by 2050 and we use our current emissions as a start,
+// so the % to cut by is 100 divided by the number of years we have
+const cutPerYearPrcnt = (100 / (2050 - currentYear)).toFixed(1);
+
 const StateDetailsPage = ({location, data}) => {
   const emissions_2018 = get_2018_emissions(data)
-  console.log('location', location)
   const currentPlace = location.pathname.split("/")[1]
 
   const placesData = getPlacesData(data)
   const emissions= emissions_2018
+  const currentPlaceData = placesData[currentPlace];
 
-  const [placeData, setPlaceData] = useState(placesData[currentPlace])
+  const placeTitle = currentPlaceData.name;
+
+  const [placeData, setPlaceData] = useState(currentPlaceData)
 
   return (
     <Layout>
       <SEO />
 
-      <div className='row d-flex flex-row'>
-        <div className='col-12 col-lg-4'>
-          <h1 className='mr-4 mb-3'>{placeData.name}</h1>
-          <ChoroplethMap emissions={emissions} sidebar={false} selected_location={currentPlace}/>
-        </div>
-        <div className='col-12 col-lg-8'>
-          <h4>Metric tons of carbon dioxide equivalent (MTCO2e) emissions</h4>
-          <StackedBarChart emissions_data={placeData.emissions}/>
-        </div>
+      <div className='col-12 c-4'>
+        <h1 className='mr-4 mb-3'>{placeData.name}</h1>
+        <ChoroplethMap emissions={emissions} sidebar={false} selected_location={currentPlace}/>
+      </div>
+      <div className='col-12'>
+        <p class="h1 mt-5 mb-5">
+          To get to <strong>zero</strong> by 2050, {placeTitle} must
+          cut climate pollution by <strong>{cutPerYearPrcnt}% a year.</strong>
+        </p>
+
+        <p class="h4 font-weight-bold">Emissions in {placeTitle}</p>
+        <p class="h6 text-muted">
+          Metric tons of carbon dioxide equivalent (MTCO2e) emissions
+          </p>
+        <StackedBarChart emissions_data={placeData.emissions}/>
+
+        <p class="h1 text-center mt-5">We can do it. Here's how.</p>
+
+        <hr/>
+      </div>
+      <div className='col-12'>
+        <h2 class="h5">Buildings</h2>
+
+        <strong>?%</strong>
+
+        <hr/>
+      </div>
+      <div className='col-12'>
+        <h2 class="h5">Getting around</h2>
+
+        <strong>?%</strong>
+
+        <hr/>
+      </div>
+      <div className='col-12'>
+        <h2 class="h5">Power generation</h2>
+
+        <strong>?%</strong>
+
+        <hr/>
       </div>
     </Layout>
   )

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -107,18 +107,25 @@ const StateDetailsPage = ({location, data}) => {
 
   const currPlaceData = placesData[currentPlace]
 
-  // Get the last year of emissions data we have to use for showing the
-  // breakdown of how much emission comes from each source in this state
-  const placeEmissions = currPlaceData.emissions[currPlaceData.emissions.length - 1]
+  let buildingsPrcnt, powerPrcnt, transportPrcnt;
 
-  const totalLatestEmissions = placeEmissions.buildings +
-    placeEmissions.dirty_power +
-    placeEmissions.dumps_farms_industrial_other +
-    placeEmissions.transportation
+  // NOTE: We don't have emissions for all states (like Guam)
+  const placeAllEmissions = currPlaceData.emissions;
 
-  const buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1)
-  const powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1)
-  const transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1)
+  if (placeAllEmissions) {
+    // Get the last year of emissions data we have to use for showing the
+    // breakdown of how much emission comes from each source in this state
+    const placeEmissions = placeAllEmissions[placeAllEmissions.length - 1]
+
+    const totalLatestEmissions = placeEmissions.buildings +
+      placeEmissions.dirty_power +
+      placeEmissions.dumps_farms_industrial_other +
+      placeEmissions.transportation
+
+    buildingsPrcnt = (placeEmissions.buildings / totalLatestEmissions * 100).toFixed(1)
+    powerPrcnt = (placeEmissions.dirty_power / totalLatestEmissions * 100).toFixed(1)
+    transportPrcnt = (placeEmissions.transportation / totalLatestEmissions * 100).toFixed(1)
+  }
 
   const placeTitle = currPlaceData.name
 
@@ -132,6 +139,8 @@ const StateDetailsPage = ({location, data}) => {
         <h1 className='mr-4 mb-3'>{placeData.name}</h1>
         <ChoroplethMap emissions={countryEmissions} sidebar={false} selected_location={currentPlace}/>
       </div>
+
+      { !placeData.emissions }
 
       {/* Intro Section */}
       <div className='col-12'>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -126,7 +126,13 @@ footer {
 }
 
 .custom-tooltip {
-	background-color: white;
-	padding: 5px;
-	box-shadow: 0 1px 2px #bdbdbd;
+    background-color: white;
+    padding: 5px;
+    box-shadow: 0 1px 2px #bdbdbd;
+}
+
+.action-panel {
+    padding: 2rem;
+    margin:  3rem 0;
+    background-color: #f3f3f3;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,7 +17,7 @@ a, a:hover, a:active, .page-link {
     text-align: right;
 }
 
-.recharts-cartesian-axis-tick {    
+.recharts-cartesian-axis-tick {
     font-size: 0.8rem;
 }
 
@@ -53,9 +53,10 @@ a, a:hover, a:active, .page-link {
     background: #aaa;
 }
 
-.mapSelected {
-    stroke:#421B49;
-    stroke-width:4;
+/* Style focused <path> elements or selected state */
+path:focus, .mapSelected {
+    stroke: #421B49;
+    stroke-width: 4;
 }
 
 .legendKey {


### PR DESCRIPTION
## Overview

Create the basic layout of the state details page, based on the [related mocks](https://app.moqups.com/pcSQvUMmsyAa1SN58KaKg1EKuYRs8iRX/view/page/a97a1436c).

This includes all of the text and the proper emissions by category % figures for each state, but does not include any new graphs or images. I also didn't add placeholders for every single image since that feels overkill and the layout could change depending on the images we end up going with.

Closes #20.

### Demo

| Intro | First Section |
| --- | --- |
| ![Screenshot from 2022-03-13 16-11-36](https://user-images.githubusercontent.com/3187531/158079457-5bdbdc50-78c1-4abc-9d9a-b17b35690296.png) | ![Screenshot from 2022-03-13 16-11-49](https://user-images.githubusercontent.com/3187531/158079461-e710cece-8ea5-4a0f-89b3-502581d1ce5c.png) |

### Notes

I was digging into the [React SVG Map](https://github.com/VictorCazanave/react-svg-map) package to see how I could exctract out and render the individual states, but honestly it looks like a huge pain since each state path is relative to the coordinates of the overall whole US canvas. I'd probably need to manipulate the viewbox to basically crop in on each state one by one and that's... a lot.

## Testing Instructions

- Go to a few state details pages and confirm you see reasonable text and that the % by category are all accurate